### PR TITLE
LPD-41330 Modifications to truncate the nanoseconds into milliseconds

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
@@ -27,6 +27,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -154,8 +155,11 @@ public class DateTimeObjectFieldBusinessType
 		ZonedDateTime zonedDateTime = ZonedDateTime.of(
 			localDateTime, ZoneId.of(sourceTimeZoneId));
 
-		return LocalDateTime.ofInstant(
+		LocalDateTime localDateTimeOfInstant = LocalDateTime.ofInstant(
 			zonedDateTime.toInstant(), ZoneId.of(targetTimeZoneId));
+
+		return localDateTimeOfInstant.truncatedTo(
+			ChronoUnit.MINUTES);
 	}
 
 	@Reference


### PR DESCRIPTION
Modifications made to truncate the DueDate used on test, from nanoseconds to milliseconds, avoiding the error on the SalesforceObjectEntryManagerImplTest.testGetObjectEntries test